### PR TITLE
fix(core): add discriminator only with anyOf

### DIFF
--- a/pydantic_openapi_helper/core.py
+++ b/pydantic_openapi_helper/core.py
@@ -118,11 +118,6 @@ def get_openapi(
             }
             properties['type'] = typ
 
-        if inheritance:
-            # add descriminator to every object
-            # in Ladybug Tools libraries it is always the type property
-            s['discriminator'] = {'propertyName': 'type'}
-
         # add format to numbers and integers
         # this is helpful for C# generators
         for prop in properties:
@@ -135,6 +130,10 @@ def get_openapi(
                     for item in properties[prop]['anyOf']:
                         new_any_of.append(set_format(item))
                     properties[prop]['anyOf'] = new_any_of
+                    # add descriminator to every object
+                    # in Ladybug Tools libraries it is always the type property
+                    if inheritance:
+                        properties[prop]['discriminator'] = {'propertyName': 'type'}
                 else:
                     continue
 


### PR DESCRIPTION
Using discriminator breaks redocly docs for nested objects. This change limits adding discriminators to only when anyOf key is used.

@MingboPeng , let me know if this breaks anything on dotnet side and we can figure out another solution.