### PR TITLE
fix(inheritance): Add elements not found in schema

### DIFF
--- a/pydantic_openapi_helper/inheritance.py
+++ b/pydantic_openapi_helper/inheritance.py
@@ -314,7 +314,7 @@ def class_mapper(models, find_and_replace=None):
     schemas = get_schemas_inheritance(models)
 
     missing_items = {k: v for k,
-                     v in mapper.items() if k not in schemas.keys()}
+                     v in mapper.items() if k not in schemas}
 
     enums = {}
     for name in schemas:


### PR DESCRIPTION
Re: pollination/pollination-server#194

The `RoleEnum` is not found from the call to `pydantic.schema.schema` and thus isn't added to the `enums` dictionary by the loop on line 320 in `inheritance.py`. This adds the missing elements to the `enums` dictionary.

I've tested this interactively against `pollination-server`. The generated JSONs with this change are [here](https://storage.cloud.google.com/lbt-blobs/misc-dev-blobs/pydantic-openapi-helper/openapi_mapper.json). I'm not sure if this is how it needs to work for C# code generation necessarily, though.